### PR TITLE
Fix macOS "bad file descriptor" issue (empty files)

### DIFF
--- a/bagbak.go
+++ b/bagbak.go
@@ -193,7 +193,7 @@ func (l *BagBak) Run(param BagBakParam) error {
 					if err != nil {
 						panic(err)
 					}
-					f, err := os.OpenFile(filename, os.O_CREATE, os.FileMode(stat.Get("mode").ToInt()))
+					f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, os.FileMode(stat.Get("mode").ToInt()))
 					if err != nil {
 						panic(err)
 					}


### PR DESCRIPTION
On macOS the "O_WRONLY" flag is needed. If O_CREATE is used only, the "info.F.Write(data)" function returns error code "bad file descriptor" and the files created remain empty.